### PR TITLE
Record which reference body drove each robot link, in the .rrd itself

### DIFF
--- a/mikumotion/motion_retargeting.py
+++ b/mikumotion/motion_retargeting.py
@@ -237,5 +237,8 @@ class MotionRetargetingIK:
         if viewer is not None:
             viewer.close()
 
-        path = self.store.write_robot_motion(self.motion_name, self.target_motion, self.urdf_path)
+        # the solve pairs two rigs that do not share a vocabulary, so the file records which
+        # reference body each robot link was solved from
+        path = self.store.write_robot_motion(self.motion_name, self.target_motion,
+                                             self.urdf_path, list(self.retargeted_bodies))
         print(f"Results saved to {path}")

--- a/mikumotion/motion_sequence.py
+++ b/mikumotion/motion_sequence.py
@@ -30,6 +30,12 @@ Both layers store bodies the same way, so one writer and one reader serve both:
     /<robot>/tf_static                the URDF's fixed transforms
     /<robot>/visual_geometries/...    the URDF's geometry, named by Rerun's URDF loader
 
+A robot layer names its bodies after the robot's own links, and the reference layer names
+its bodies after the source rig. For zamuza on lite_pro those are two different vocabularies,
+``torso`` against ``chest``. The robot layer's ``reference_body_names`` property records the
+pairing, one reference body per entry of ``body_names``, so a reader can line the two layers
+up without knowing which retarget map produced the file.
+
 The two pose sets are different data, not a duplicate. ``reference/`` is what the IK aims
 at, and what a training run tracks. ``<robot>/`` is what the IK reached.
 
@@ -419,7 +425,10 @@ def read_blueprint_overrides(path):
 
 
 def read_properties(path):
-    """Read the recording properties (fps, robot, joint_names, body_names) from an ``.rrd``."""
+    """
+    Read a recording's properties: fps and body_names, plus robot, joint_names and
+    reference_body_names on a robot layer.
+    """
     store = rr.experimental.RrdReader(str(path)).store()
     properties = {}
     for chunk in store.stream():
@@ -519,7 +528,7 @@ class MotionStore:
                        static=True, recording=stream)
         return path
 
-    def write_robot_motion(self, name, motion, urdf_path):
+    def write_robot_motion(self, name, motion, urdf_path, reference_body_names=None):
         """
         Write the solve stage as ``<robot>/<name>.rrd``, plus that robot's viewer layout.
 
@@ -532,6 +541,11 @@ class MotionStore:
         what the solve aims at, and the gap between the two is the retarget's error.
 
         ``motion`` carries the robot's joints and, in ``body_names``, at least the root link.
+
+        ``reference_body_names`` names the reference body each of those bodies was solved
+        from, in the same order, because a retarget pairs two rigs that do not share a
+        vocabulary. Leave it out when the bodies are already the reference's own, as they are
+        for an imported log, and the pairing is recorded as the identity it is.
         """
         robot = rr.urdf.UrdfTree.from_file_path(urdf_path).name
         tree = rr.urdf.UrdfTree.from_file_path(
@@ -553,6 +567,7 @@ class MotionStore:
                 fps=motion.fps,
                 joint_names=list(motion.joint_names),
                 body_names=list(motion.body_names),
+                reference_body_names=list(reference_body_names or motion.body_names),
             ), recording=stream)
 
             tree.log_urdf_to_recording(recording=stream)

--- a/tests/test_motion_sequence.py
+++ b/tests/test_motion_sequence.py
@@ -5,7 +5,7 @@ import pytest
 
 from mikumotion.motion_sequence import (REFERENCE, MotionSequence, MotionStore, body_frame,
                                         fill_body_velocities, quat_to_wxyz, quat_to_xyzw,
-                                        read_blueprint_overrides, read_entity_columns,
+                                        read_blueprint_overrides, read_entity_columns, read_properties,
                                         read_entity_components)
 
 URDF = """<?xml version="1.0"?>
@@ -268,6 +268,37 @@ def test_a_motion_opened_alone_hides_its_velocity_arrows(store):
     """Both layers embed a blueprint, so either file opens sensibly on its own."""
     assert read_blueprint_overrides(store.reference_file("clip")) == {
         "/reference/body/linear_velocities", "/reference/body/angular_velocities"}
+
+
+def test_a_retarget_records_which_reference_body_drove_each_link(tmp_path):
+    """
+    A retarget pairs two rigs that do not share a vocabulary: the reference calls a body
+    ``torso`` where the robot calls its link ``chest``. Without the pairing in the file, a
+    reader has to know which retarget map produced it.
+    """
+    urdf = tmp_path / "testbot.urdf"
+    urdf.write_text(URDF)
+    store = MotionStore(tmp_path / "motions")
+
+    solved = MotionSequence(num_frames=NUM_FRAMES, joint_names=JOINT_NAMES,
+                            body_names=["base", "arm"], fps=50)
+    store.write_reference_motion("clip", build_motion())
+    store.write_robot_motion("clip", solved, urdf, ["pelvis", "upper_arm"])
+
+    properties = read_properties(store.robot_file("clip", "testbot"))
+    pairs = dict(zip([str(v) for v in properties["reference_body_names"]],
+                     [str(v) for v in properties["body_names"]]))
+    assert pairs == {"pelvis": "base", "upper_arm": "arm"}
+
+
+def test_an_imported_log_pairs_each_body_with_itself(store):
+    """
+    An imported log is not retargeted, so its bodies are already the reference's own. The
+    pairing is written anyway, as the identity it is, so a reader never has to branch.
+    """
+    properties = read_properties(store.robot_file("clip", "testbot"))
+    assert [str(v) for v in properties["reference_body_names"]] == BODY_NAMES
+    assert [str(v) for v in properties["body_names"]] == BODY_NAMES
 
 
 def test_robot_layers_do_not_collide(tmp_path):


### PR DESCRIPTION
A retarget pairs two rigs that do not share a vocabulary. For zamuza on lite_pro, the reference layer calls a body `torso` where the robot layer calls its link `chest`, and `left_upper_arm` where the robot calls it `left_shoulder_yaw`.

That pairing lived only in `presets.ZAMUZA_TO_LITE_PRO`, so reading the two layers of a motion together meant already knowing which retarget map had produced the file. Anyone outside this repo — a training environment reading the `.rrd` directly — had no way to line them up.

## The change

The robot layer already stored `body_names`, the robot's links **in retarget-map order**, so the pairing needs one aligned list rather than a new structure:

```
reference_body_names[i]  ->  body_names[i]
torso                    ->  chest
left_upper_arm           ->  left_shoulder_yaw
left_lower_leg           ->  left_knee_pitch
```

`write_robot_motion` takes an optional `reference_body_names`, and `MotionRetargetingIK` passes the source names it already holds. Nothing changes on the read side: `read_properties` is public and simply returns the extra key.

Read straight out of `lite_pro/zamuza.rrd`, with no reference to `presets.py`:

```
pelvis             -> pelvis
torso              -> chest
head               -> head
left_upper_arm     -> left_shoulder_yaw
left_lower_arm     -> left_elbow_pitch
left_upper_leg     -> left_hip_yaw
left_lower_leg     -> left_knee_pitch
...
```

## Two decisions worth a look

**The identity pairing is written too, rather than left out.** An imported log is not retargeted, so its bodies are already the reference's own. Omitting the field there would make every consumer branch on its absence; writing it costs 75 strings on `lite_pro_tracking` and lets a reader `zip` the two lists unconditionally. Both cases have a test.

**The orientation cost is deliberately not stored.** `ZAMUZA_TO_LITE_PRO` also carries a per-pair cost (0.5 for pinned limbs, 0.1 for pole targets). That configures the solver rather than pairing the layers, so it stays out. Easy to add as a second parallel array if it turns out to be wanted as provenance.

## Regenerating

Both robot layers were rewritten to carry the field. Neither needed a re-solve — a robot layer stores the poses its solve reached, so it can be rebuilt from itself, and every array was verified against what was read out of it first to `atol=1e-6`.

The stored body order was checked against the preset before relying on it, rather than assumed to have survived the dict into `MotionSequence`:

```
stored body_names == preset targets, in order: True
```

45 tests, up from 43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)