### PR TITLE
Publish docs/ to Pages instead of the whole repository

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,8 +36,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
-          path: '.'
+          path: 'docs'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
upload-pages-artifact takes a directory and serves its index.html at the site root. Uploading the repository root put the page at /MikuMotionTools/docs/ and left the site root without an index.html, which is the 404 that every link to the site hit.